### PR TITLE
should use relative path from constructor ts file for contract import

### DIFF
--- a/packages/typechain-polkadot/src/templates/constructors.hbs
+++ b/packages/typechain-polkadot/src/templates/constructors.hbs
@@ -1,6 +1,7 @@
 import {CodePromise} from "@polkadot/api-contract";
 import type {KeyringPair} from "@polkadot/keyring/types";
 import Files from "fs";
+import path from "path";
 import type {ApiPromise} from "@polkadot/api";
 import {_signAndSend, SignAndSendSuccessResponse} from "../_sdk/tx";
 import type {ConstructorOptions} from "../_sdk/types";
@@ -32,7 +33,7 @@ export default class Constructors {
     	{{/each}}
     		__options ? : ConstructorOptions,
     	) {
-    		const __contract = JSON.parse(Files.readFileSync("{{{../pathToContractFile}}}").toString());
+    		const __contract = JSON.parse(Files.readFileSync(path.resolve(__dirname, "{{{../pathToContractFile}}}")).toString());
 
 			const code = new CodePromise(this.nativeAPI, __contract, __contract.source.wasm);
 


### PR DESCRIPTION
The import path of `.contract` file should be relative path from constructors' ts file.
Otherwise, the result will vary depends on where you execute the program.

Imagine the below situation. In the current implementation, if `my_psp22.ts` uses  `Files.readFileSync("./artifacts/my_psp22.contract")`, then this works only when current directory (where you execute index.ts) is at `my_project`. This should be unexpected behaviour.
```
my_project
    |
    |-- index.ts
    |-- artifacts
    |         |-- my_psp22.contract
    |         |-- my_psp22.json
    |
    |-- typedContract
              |-- constructors
                          |-- my_psp22.ts
```
