### PR TITLE
metadata.json -> {contract_name}.json

### DIFF
--- a/packages/typechain-compiler/index.ts
+++ b/packages/typechain-compiler/index.ts
@@ -111,7 +111,7 @@ function main() {
 			__writeFileSync(
 				artifactsPath,
 				`${targetInfo.name}.json`,
-				FsAPI.readFileSync(PathAPI.resolve(targetInfo.path, 'metadata.json'), "utf8")
+				FsAPI.readFileSync(PathAPI.resolve(targetInfo.path, `${targetInfo.name}.json`), "utf8")
 			);
 
 			__writeFileSync(


### PR DESCRIPTION
metadata.json is renamed to {contract_name}.json from the upstream: https://github.com/paritytech/cargo-contract/pull/952