### PR TITLE
Make available on the front-end

### DIFF
--- a/packages/typechain-polkadot/src/templates/events.hbs
+++ b/packages/typechain-polkadot/src/templates/events.hbs
@@ -1,6 +1,7 @@
 import type * as EventTypes from '../event-types/{{{fileName}}}';
 import type {ContractPromise} from "@polkadot/api-contract";
 import type {ApiPromise} from "@polkadot/api";
+import EVENT_DATA_TYPE_DESCRIPTIONS from '../event-data/{{{fileName}}}.json';
 import {getEventTypeDescription} from "../shared/utils";
 import {handleEventReturn} from "@727-ventures/typechain-types";
 
@@ -25,7 +26,7 @@ export default class EventsClass {
 				_event[event.args[i]!.name] = args[i]!.toJSON();
 			}
 
-			callback(handleEventReturn(_event, getEventTypeDescription('{{name}}', '{{../fileName}}')) as EventTypes.{{name}});
+			callback(handleEventReturn(_event, getEventTypeDescription('{{name}}', EVENT_DATA_TYPE_DESCRIPTIONS)) as EventTypes.{{name}});
 		};
 
 		return this.__subscribeOnEvent(callbackWrapper, (eventName : string) => eventName == '{{name}}');

--- a/packages/typechain-polkadot/src/templates/mixed-methods.hbs
+++ b/packages/typechain-polkadot/src/templates/mixed-methods.hbs
@@ -16,6 +16,8 @@ import {getTypeDescription} from './../shared/utils';
 // @ts-ignore
 import type {EventRecord} from "@polkadot/api/submittable";
 import {decodeEvents} from "../shared/utils";
+import DATA_TYPE_DESCRIPTIONS from '../data/{{{fileName}}}.json';
+import EVENT_DATA_TYPE_DESCRIPTIONS from '../event-data/{{{fileName}}}.json';
 {{#if additionalImports.length}}
 {{#each additionalImports}}
 import { {{#each values}}{{{this}}}{{#unless @last}}, {{/unless}}{{/each}} } from '{{{path}}}';
@@ -54,7 +56,7 @@ export default class Methods {
 		__options: {{#if payable}}GasLimitAndRequiredValue{{else}}GasLimit{{/if}},
 	){{{buildReturnType this}}}{
 		return {{{buildReturn this}}} "{{{toCamelCaseForFunctions originalName}}}", {{#ifTx this}}(events: EventRecord) => {
-			return decodeEvents(events, this.__nativeContract, "{{../fileName}}");
+			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, {{/ifTx}}[{{#each args}}{{{name}}}{{#unless @last}}, {{/unless}}{{/each}}], __options{{{buildWrapper this}}});
 	}
 

--- a/packages/typechain-polkadot/src/templates/query.hbs
+++ b/packages/typechain-polkadot/src/templates/query.hbs
@@ -11,6 +11,7 @@ import type BN from 'bn.js';
 //@ts-ignore
 import {ReturnNumber} from '@727-ventures/typechain-types';
 import {getTypeDescription} from './../shared/utils';
+import DATA_TYPE_DESCRIPTIONS from '../data/{{{fileName}}}.json';
 {{#if additionalImports.length}}
 {{#each additionalImports}}
 import { {{#each values}}{{{this}}}{{#unless @last}}, {{/unless}}{{/each}} } from '{{{path}}}';
@@ -46,7 +47,7 @@ export default class Methods {
 	{{/each}}
 		__options ? : {{#if payable}}GasLimitAndRequiredValue{{else}}GasLimit{{/if}},
 	){{{buildReturnType this}}}{
-		return {{{buildReturn this}}} "{{{toCamelCaseForFunctions originalName}}}", [{{#each args}}{{{name}}}{{#unless @last}}, {{/unless}}{{/each}}], __options {{#buildWrapper this}}{{fileName}}{{/buildWrapper}});
+		return {{{buildReturn this}}} "{{{toCamelCaseForFunctions originalName}}}", [{{#each args}}{{{name}}}{{#unless @last}}, {{/unless}}{{/each}}], __options {{{buildWrapper this}}});
 	}
 
 {{/each}}

--- a/packages/typechain-polkadot/src/templates/raw/shared/utils.ts
+++ b/packages/typechain-polkadot/src/templates/raw/shared/utils.ts
@@ -2,17 +2,15 @@ import fs from "fs";
 import type {ContractPromise} from "@polkadot/api-contract";
 import {handleEventReturn} from "@727-ventures/typechain-types";
 
-export function getTypeDescription(id: number | string, fileName: string): any {
-	const types = JSON.parse(fs.readFileSync(__dirname + `/../data/${fileName}.json`, 'utf8'));
+export function getTypeDescription(id: number | string, types: any): any {
 	return types[id];
 }
 
-export function getEventTypeDescription(name: string, fileName: string): any {
-	const types = JSON.parse(fs.readFileSync(__dirname + `/../event-data/${fileName}.json`, 'utf8'));
+export function getEventTypeDescription(name: string, types: any): any {
 	return types[name];
 }
 
-export function decodeEvents(events: any[], contract: ContractPromise, fileName: string): any[] {
+export function decodeEvents(events: any[], contract: ContractPromise, types: any): any[] {
 	return events.filter((record: any) => {
 		const { event } = record;
 
@@ -30,7 +28,7 @@ export function decodeEvents(events: any[], contract: ContractPromise, fileName:
 			_event[event.args[i]!.name] = args[i]!.toJSON();
 		}
 
-		handleEventReturn(_event, getEventTypeDescription(event.identifier.toString(), fileName));
+		handleEventReturn(_event, getEventTypeDescription(event.identifier.toString(), types));
 
 		return {
 			name: event.identifier.toString(),

--- a/packages/typechain-polkadot/src/templates/tx-sign-and-send.hbs
+++ b/packages/typechain-polkadot/src/templates/tx-sign-and-send.hbs
@@ -10,6 +10,7 @@ import type BN from 'bn.js';
 // @ts-ignore
 import type {EventRecord} from "@polkadot/api/submittable";
 import {decodeEvents} from "../shared/utils";
+import EVENT_DATA_TYPE_DESCRIPTIONS from '../event-data/{{{fileName}}}.json';
 {{#if additionalImports.length}}
 {{#each additionalImports}}
 import { {{#each values}}{{{this}}}{{#unless @last}}, {{/unless}}{{/each}} } from '{{{path}}}';
@@ -45,7 +46,7 @@ export default class Methods {
 		__options ? : {{#if payable}}GasLimitAndRequiredValue{{else}}GasLimit{{/if}},
 	){{{buildReturnType this}}}{
 		return {{{buildReturn this}}} "{{{toCamelCaseForFunctions originalName}}}", (events: EventRecord) => {
-			return decodeEvents(events, this.__nativeContract, "{{../fileName}}");
+			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [{{#each args}}{{{name}}}{{#unless @last}}, {{/unless}}{{/each}}], __options);
 	}
 

--- a/packages/typechain-polkadot/src/utils/handlebars-helpers.ts
+++ b/packages/typechain-polkadot/src/utils/handlebars-helpers.ts
@@ -88,12 +88,12 @@ Handlebars.registerHelper( 'buildReturnType', function(fn: Method) {
 	return '';
 });
 
-Handlebars.registerHelper('buildWrapper', function(fn: Method, fileName: any) {
+Handlebars.registerHelper('buildWrapper', function(fn: Method) {
 	if(fn.methodType == 'query' && fn.returnType?.tsStr == 'ReturnNumber') {
 		return ', (result) => { return new ReturnNumber(result as (number | string)); }';
 	}
 	if(fn.methodType == 'query' && fn.returnType && fn.returnType?.tsStr !== 'null' && fn.returnType?.tsStr !== 'number' && fn.returnType?.tsStr !== 'string' && fn.returnType?.tsStr !== 'boolean') {
-		return `, (result) => { return handleReturnType(result, getTypeDescription(${fn.returnType?.id}, '${fileName.data.root.fileName}')); }`;
+		return `, (result) => { return handleReturnType(result, getTypeDescription(${fn.returnType?.id}, DATA_TYPE_DESCRIPTIONS)); }`;
 	}
 });
 


### PR DESCRIPTION
Changed to use import instead of fs to make the generated code available on the front end.